### PR TITLE
makes the CHANGELOG docs checker optional

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,7 @@
 # TBD
 
 ###
-- The `docs-checker` will only check for missing links now, as the check
-for CHANGELOG will happen via a different checker that checks for conventional commits.
+- The `docs-checker` can be toggled off, in order to support a repo with conventional commits & its related checker
 
 # 0.2.1
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # TBD
 
+###
+- The `docs-checker` will only check for missing links now, as the check
+for CHANGELOG will happen via a different checker that checks for conventional commits.
+
 # 0.2.1
 
 ### Changes

--- a/orb.yml
+++ b/orb.yml
@@ -21,15 +21,6 @@ jobs:
     steps:
       - checkout
 
-      # Gotchas I discovered when writing this:
-      # - Without the '--no-pager' flag, Git will print "WARNING: Terminal is not fully functional" and not display any output
-      # - Circle has no way of getting the PR base branch, so we have to hardcode master :( See: https://ideas.circleci.com/cloud-feature-requests/p/provide-env-variable-for-branch-name-targeted-by-pull-request
-      # - The --exit-code flag to git-diff returns 0 on no changes, 1 on changes
-      # - We have to use 'origin/master' rather than 'master' because Circle does a shallow checkout, and 'master' gets set to something weird and wrong that makes the check buggy
-      - run:
-          name: Verify changelog was updated
-          command: "! git --no-pager diff --exit-code origin/master...HEAD docs/changelog.md"
-
       - run:
           name: Check links in Markdown docs
           command: |

--- a/orb.yml
+++ b/orb.yml
@@ -20,7 +20,7 @@ jobs:
         type: string
       should-check-changelog:
         default: true
-        description: Governs whether the changelog checker would run, defaults to false
+        description: Governs whether the changelog checker would run
         type: boolean
     steps:
       - checkout

--- a/orb.yml
+++ b/orb.yml
@@ -30,7 +30,7 @@ jobs:
       # - Circle has no way of getting the PR base branch, so we have to hardcode master :( See: https://ideas.circleci.com/cloud-feature-requests/p/provide-env-variable-for-branch-name-targeted-by-pull-request
       # - The --exit-code flag to git-diff returns 0 on no changes, 1 on changes
       # - We have to use 'origin/master' rather than 'master' because Circle does a shallow checkout, and 'master' gets set to something weird and wrong that makes the check buggy
-      
+      # We put this behind a parameter to toggle whether we should run it
       - when:
         condition: <<parameters.should-check-changelog>>
         run:

--- a/orb.yml
+++ b/orb.yml
@@ -18,8 +18,24 @@ jobs:
         default: "{}"
         description: Config JSON passed to markdown-link-check package (see https://www.npmjs.com/package/markdown-link-check for full details)
         type: string
+      should-check-changelog:
+        default: true
+        description: Governs whether the changelog checker would run, defaults to false
+        type: boolean
     steps:
       - checkout
+
+      # Gotchas I discovered when writing this:
+      # - Without the '--no-pager' flag, Git will print "WARNING: Terminal is not fully functional" and not display any output
+      # - Circle has no way of getting the PR base branch, so we have to hardcode master :( See: https://ideas.circleci.com/cloud-feature-requests/p/provide-env-variable-for-branch-name-targeted-by-pull-request
+      # - The --exit-code flag to git-diff returns 0 on no changes, 1 on changes
+      # - We have to use 'origin/master' rather than 'master' because Circle does a shallow checkout, and 'master' gets set to something weird and wrong that makes the check buggy
+      
+      - when:
+        condition: <<parameters.should-check-changelog>>
+        run:
+          name: Verify changelog was updated
+          command: "! git --no-pager diff --exit-code origin/master...HEAD docs/changelog.md"
 
       - run:
           name: Check links in Markdown docs


### PR DESCRIPTION
This sets stage for conventional commits, we will switch this off in the monorepo in this PR https://github.com/kurtosis-tech/kurtosis/pull/613