### PR TITLE
fix: use 3.11.2 as latest is broken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,29 +8,29 @@ orbs:
 workflows:
   build:
     jobs:
-      # # -- End PR check jobs ---------------------------------------
-      # - kurtosis-docs-checker/check-docs:
-      #     markdown-link-check-config-json: |
-      #       {
-      #           "ignorePatterns": [
-      #               {
-      #                   "pattern": "https://github.com/kurtosis-tech/kurtosis-docs-checker-orb"
-      #               }
-      #           ]
-      #       }
-      #     should-check-changelog: false
-      #     # using our inbuilt ignore while https://github.com/tcort/markdown-link-check/issues/246 stays open
-      #     dir-to-exclude: './CHANGELOG.md'
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - main
-      # - orb-tools/lint:
-      #     filters:
-      #       branches:
-      #         ignore:
-      #           - main
-      # # -- End PR check jobs ---------------------------------------
+      # -- End PR check jobs ---------------------------------------
+      - kurtosis-docs-checker/check-docs:
+          markdown-link-check-config-json: |
+            {
+                "ignorePatterns": [
+                    {
+                        "pattern": "https://github.com/kurtosis-tech/kurtosis-docs-checker-orb"
+                    }
+                ]
+            }
+          should-check-changelog: false
+          # using our inbuilt ignore while https://github.com/tcort/markdown-link-check/issues/246 stays open
+          dir-to-exclude: './CHANGELOG.md'
+          filters:
+            branches:
+              ignore:
+                - main
+      - orb-tools/lint:
+          filters:
+            branches:
+              ignore:
+                - main
+      # -- End PR check jobs ---------------------------------------
 
       # -- Artifact-publishing jobs --------------------------------
       - orb-tools/publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,29 +8,29 @@ orbs:
 workflows:
   build:
     jobs:
-      # -- End PR check jobs ---------------------------------------
-      - kurtosis-docs-checker/check-docs:
-          markdown-link-check-config-json: |
-            {
-                "ignorePatterns": [
-                    {
-                        "pattern": "https://github.com/kurtosis-tech/kurtosis-docs-checker-orb"
-                    }
-                ]
-            }
-          should-check-changelog: false
-          # using our inbuilt ignore while https://github.com/tcort/markdown-link-check/issues/246 stays open
-          dir-to-exclude: './CHANGELOG.md'
-          filters:
-            branches:
-              ignore:
-                - main
-      - orb-tools/lint:
-          filters:
-            branches:
-              ignore:
-                - main
-      # -- End PR check jobs ---------------------------------------
+      # # -- End PR check jobs ---------------------------------------
+      # - kurtosis-docs-checker/check-docs:
+      #     markdown-link-check-config-json: |
+      #       {
+      #           "ignorePatterns": [
+      #               {
+      #                   "pattern": "https://github.com/kurtosis-tech/kurtosis-docs-checker-orb"
+      #               }
+      #           ]
+      #       }
+      #     should-check-changelog: false
+      #     # using our inbuilt ignore while https://github.com/tcort/markdown-link-check/issues/246 stays open
+      #     dir-to-exclude: './CHANGELOG.md'
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - main
+      # - orb-tools/lint:
+      #     filters:
+      #       branches:
+      #         ignore:
+      #           - main
+      # # -- End PR check jobs ---------------------------------------
 
       # -- Artifact-publishing jobs --------------------------------
       - orb-tools/publish:

--- a/orb.yml
+++ b/orb.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             set -eou pipefail
 
-            sudo npm install -g markdown-link-check
+            sudo npm install -g markdown-link-check@3.11.2
             config_filepath="$(mktemp)"
             cat \<< EOF > "${config_filepath}"
             <<parameters.markdown-link-check-config-json>>


### PR DESCRIPTION
the current version is broken https://github.com/tcort/markdown-link-check/issues/297

Changelog picked up from commits here:

fix: use 3.11.2 as latest is broken