### PR TITLE
chore: upgrade node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   # This orb actually validates its own docs
-  kurtosis-docs-checker: kurtosis-tech/docs-checker@0.2.5
+  kurtosis-docs-checker: kurtosis-tech/docs-checker@0.2.9
   orb-tools: circleci/orb-tools@10.0
 
 workflows:

--- a/orb.yml
+++ b/orb.yml
@@ -11,7 +11,7 @@ display:
 jobs:
   check-docs:
     docker:
-      - image: cimg/node:18.20.0
+      - image: cimg/node:22.7.0
     resource_class: small
     parameters:
       markdown-link-check-config-json:


### PR DESCRIPTION
Copy of https://github.com/kurtosis-tech/kurtosis-docs-checker-orb/pull/27

Changelog picked up from commits here:

chore: upgrade node version